### PR TITLE
adds possibility to include user defined dict in serialized nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Handler params are:
 
 
 ### Support for custom data
-Both `Workflow`and `WorkflowNode` have a `user_params` dictionary member that can be used to store 
+Both `Workflow`and `WorkflowNode` have a `custom_payload` dictionary member that can be used to store 
 additional data. For example, one can use those dictionnary to store some application specific 
 metadata.
 
@@ -136,7 +136,7 @@ for task in task_list:
     sig = create_celery_task(task)
     sig.freeze()
     node = wf.add_signature(sig)
-    node.user_params['user_id'] = task.user_id
+    node.custom_payload['user_id'] = task.user_id
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ Handler params are:
 - workflow instance
 - payload - None
 
+
+### Support for custom data
+Both `Workflow`and `WorkflowNode` have a `user_params` dictionary member that can be used to store 
+additional data. For example, one can use those dictionnary to store some application specific 
+metadata.
+
+```python
+...
+wf = Workflow()
+for task in task_list:
+    sig = create_celery_task(task)
+    sig.freeze()
+    node = wf.add_signature(sig)
+    node.user_params['user_id'] = task.user_id
+...
+```
+
+
 ## TODO
 - Proper documentation (e.g. sphinx)
 - Some integration tests?

--- a/celery_dyrygent/workflows/node.py
+++ b/celery_dyrygent/workflows/node.py
@@ -28,6 +28,7 @@ class WorkflowNode(object):
         # dict will be able to hold additional info, e.g to run task only if
         # on of dependency fails e.g. at least twice
         self.dependencies = {}
+        self.user_params = {}
 
     def add_dependency(self, other_node, options=None):
         assert isinstance(other_node, WorkflowNode)
@@ -46,12 +47,17 @@ class WorkflowNode(object):
         """
         Packs internals into a serializable dict
         """
-        return dict(
+        d = dict(
             id=self.id,
             # celery signatures are serializable so it will work
             signature=self.signature,
             dependencies=self.dependencies,
         )
+        if not self.user_params :
+            return d
+        else:
+            d.update(dict(user_params=self.user_params))
+            return d
 
     @classmethod
     def from_dict(cls, data_dict):
@@ -62,4 +68,8 @@ class WorkflowNode(object):
         sig = entities.Signature(data_dict['signature'])
         obj = cls(sig)
         obj.dependencies = data_dict['dependencies']
+        if 'user_params' in data_dict:
+            obj.user_params = data_dict['user_params']
+        else:
+            obj.user_params = {}
         return obj

--- a/celery_dyrygent/workflows/node.py
+++ b/celery_dyrygent/workflows/node.py
@@ -28,7 +28,7 @@ class WorkflowNode(object):
         # dict will be able to hold additional info, e.g to run task only if
         # on of dependency fails e.g. at least twice
         self.dependencies = {}
-        self.user_params = {}
+        self.custom_payload = {}
 
     def add_dependency(self, other_node, options=None):
         assert isinstance(other_node, WorkflowNode)
@@ -47,17 +47,13 @@ class WorkflowNode(object):
         """
         Packs internals into a serializable dict
         """
-        d = dict(
+        return dict(
             id=self.id,
             # celery signatures are serializable so it will work
             signature=self.signature,
             dependencies=self.dependencies,
+            custom_payload=self.custom_payload,
         )
-        if not self.user_params :
-            return d
-        else:
-            d.update(dict(user_params=self.user_params))
-            return d
 
     @classmethod
     def from_dict(cls, data_dict):
@@ -68,8 +64,5 @@ class WorkflowNode(object):
         sig = entities.Signature(data_dict['signature'])
         obj = cls(sig)
         obj.dependencies = data_dict['dependencies']
-        if 'user_params' in data_dict:
-            obj.user_params = data_dict['user_params']
-        else:
-            obj.user_params = {}
+        obj.custom_payload = data_dict.get('custom_payload', {})
         return obj

--- a/celery_dyrygent/workflows/workflow.py
+++ b/celery_dyrygent/workflows/workflow.py
@@ -235,6 +235,8 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
         # celery erorrs within tick
         self._celery_errors_within_tick = []
 
+        self.user_params = {}
+
         # create instance level logger
         self.__init_logger()
 
@@ -519,6 +521,10 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
         for attr in self.straight_serializables:
             res[attr] = getattr(self, attr)
         res['stats'] = self.stats
+
+        if self.user_params:
+            res['user_params'] = self.user_params
+
         return res
 
     @classmethod
@@ -528,6 +534,8 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
             node_id: WorkflowNode.from_dict(node_dict)
             for node_id, node_dict in workflow_dict['nodes'].items()
         }
+
+        obj.user_params = workflow_dict['user_params'] if 'user_params' in workflow_dict else {}
 
         for attr in cls.straight_serializables:
             setattr(obj, attr, workflow_dict[attr])

--- a/celery_dyrygent/workflows/workflow.py
+++ b/celery_dyrygent/workflows/workflow.py
@@ -235,7 +235,7 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
         # celery erorrs within tick
         self._celery_errors_within_tick = []
 
-        self.user_params = {}
+        self.custom_payload = {}
 
         # create instance level logger
         self.__init_logger()
@@ -521,9 +521,7 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
         for attr in self.straight_serializables:
             res[attr] = getattr(self, attr)
         res['stats'] = self.stats
-
-        if self.user_params:
-            res['user_params'] = self.user_params
+        res['custom_payload'] = self.custom_payload
 
         return res
 
@@ -535,8 +533,7 @@ class Workflow(WorkflowSignalMixin, CeleryWorkflowMixin):
             for node_id, node_dict in workflow_dict['nodes'].items()
         }
 
-        obj.user_params = workflow_dict['user_params'] if 'user_params' in workflow_dict else {}
-
+        obj.custom_payload = workflow_dict.get('custom_payload', {})
         for attr in cls.straight_serializables:
             setattr(obj, attr, workflow_dict[attr])
 

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -109,7 +109,7 @@ class TestWorkflowNode(object):
         assert d['dependencies']
         assert d['dependencies']['task-2'] is None
         assert d['dependencies']['task-3'] is None
-        assert d['custom_payload']['foo'] is "bar"
+        assert d['custom_payload']['foo'] == "bar"
         assert d['signature'] is w1.signature
 
     def test_from_dict(self):
@@ -577,34 +577,11 @@ class TestWorkflow(object):
         wf.nodes['10'].to_dict.assert_called()
 
 
+    def test_to_dict_with_custom_payload(self, wf):
         wf.custom_payload["foo"] = "bar"
         res = wf.to_dict()
-        assert res == {
-            'running': {
-                '1': True,
-                '2': False,
-            },
-            'finished': {
-                '6': True,
-                '7': False,
-            },
-            'nodes': {
-                '10': 'inner',
-            },
-            'processing_limit_ts': 500,
-            'version': 1,
-            'retry_policy': ['random', 10, 30],
-            'stats': {
-                'last_apply_async_tick': 0,
-                'ticks': 0,
-                'consecutive_celery_error_ticks': 0,
-            },
-            'id': None,
-            'state': 'INITIAL',
-            'custom_payload' : {
-                'foo': 'bar'
-            }
-        }
+        assert res['custom_payload']['foo'] == 'bar'
+
 
     def test_from_dict(self):
         wf_dict = {

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -101,12 +101,15 @@ class TestWorkflowNode(object):
         w1.add_dependency(w2)
         w1.add_dependency(w3)
 
+        w1.user_params["foo"] = "bar"
+
         d = w1.to_dict()
 
         assert d['id'] == 'task-1'
         assert d['dependencies']
         assert d['dependencies']['task-2'] is None
         assert d['dependencies']['task-3'] is None
+        assert d['user_params']['foo'] is "bar"
         assert d['signature'] is w1.signature
 
     def test_from_dict(self):
@@ -123,6 +126,26 @@ class TestWorkflowNode(object):
         assert w1.id == 'task-7'
         assert w1.signature.id == 'task-7'
         assert w1.dependencies == {'task-4': None}
+
+
+    def test_from_dict_with_user_params(self):
+        data_dict = {
+            'id': 'task-7',
+            'signature': {
+                'options': {'task_id': 'task-7'}, 'task': None,
+                'args': (), 'kwargs': {},
+            },
+            'dependencies': {'task-4': None},
+            'user_params' : {
+                'foo' : 42
+            }
+        }
+        w1 = WorkflowNode.from_dict(data_dict)
+
+        assert w1.id == 'task-7'
+        assert w1.signature.id == 'task-7'
+        assert w1.dependencies == {'task-4': None}
+        assert w1.user_params['foo'] == 42
 
 
 class TestWorkflow(object):

--- a/tests/unit/test_workflows.py
+++ b/tests/unit/test_workflows.py
@@ -101,7 +101,7 @@ class TestWorkflowNode(object):
         w1.add_dependency(w2)
         w1.add_dependency(w3)
 
-        w1.user_params["foo"] = "bar"
+        w1.custom_payload["foo"] = "bar"
 
         d = w1.to_dict()
 
@@ -109,7 +109,7 @@ class TestWorkflowNode(object):
         assert d['dependencies']
         assert d['dependencies']['task-2'] is None
         assert d['dependencies']['task-3'] is None
-        assert d['user_params']['foo'] is "bar"
+        assert d['custom_payload']['foo'] is "bar"
         assert d['signature'] is w1.signature
 
     def test_from_dict(self):
@@ -128,7 +128,7 @@ class TestWorkflowNode(object):
         assert w1.dependencies == {'task-4': None}
 
 
-    def test_from_dict_with_user_params(self):
+    def test_from_dict_with_custom_payload(self):
         data_dict = {
             'id': 'task-7',
             'signature': {
@@ -136,7 +136,7 @@ class TestWorkflowNode(object):
                 'args': (), 'kwargs': {},
             },
             'dependencies': {'task-4': None},
-            'user_params' : {
+            'custom_payload' : {
                 'foo' : 42
             }
         }
@@ -145,7 +145,7 @@ class TestWorkflowNode(object):
         assert w1.id == 'task-7'
         assert w1.signature.id == 'task-7'
         assert w1.dependencies == {'task-4': None}
-        assert w1.user_params['foo'] == 42
+        assert w1.custom_payload['foo'] == 42
 
 
 class TestWorkflow(object):
@@ -571,12 +571,13 @@ class TestWorkflow(object):
             },
             'id': None,
             'state': 'INITIAL',
+            'custom_payload':{},
         }
 
         wf.nodes['10'].to_dict.assert_called()
 
 
-        wf.user_params["foo"] = "bar"
+        wf.custom_payload["foo"] = "bar"
         res = wf.to_dict()
         assert res == {
             'running': {
@@ -600,7 +601,7 @@ class TestWorkflow(object):
             },
             'id': None,
             'state': 'INITIAL',
-            'user_params' : {
+            'custom_payload' : {
                 'foo': 'bar'
             }
         }
@@ -638,14 +639,14 @@ class TestWorkflow(object):
             }
 
             assert wf.processing_limit_ts == 5000
-            assert wf.user_params == {}
+            assert wf.custom_payload == {}
 
             mck.assert_has_calls([
                 mock.call('data'),
                 mock.call('data2'),
             ])
 
-    def test_from_dict_with_user_params(self):
+    def test_from_dict_with_custom_payload(self):
         wf_dict = {
             'finished': {'1': False},
             'running': {'2': True},
@@ -659,7 +660,7 @@ class TestWorkflow(object):
             },
             'id': None,
             'state': 'RUNNING',
-            'user_params' : {
+            'custom_payload' : {
                 'foo' : 'bar'
             }
         }
@@ -681,7 +682,7 @@ class TestWorkflow(object):
             }
 
             assert wf.processing_limit_ts == 5000
-            assert wf.user_params == {'foo': 'bar'}
+            assert wf.custom_payload == {'foo': 'bar'}
 
             mck.assert_has_calls([
                 mock.call('data'),


### PR DESCRIPTION
In my use case, I need additional data to be serialized with the workflow dag's nodes. 
This PR introduces a dict member to `WorkflowNode`, `user_params`, that can be used to convey such data.

I added tests to make sure that the new member is correctly serialized, and took care to not break retrocompatibility with existing serialized data.

This MR addresses issue #3 